### PR TITLE
Fix: Register all BFT sub-protocols during IBFT2→QBFT consensus migration

### DIFF
--- a/app/src/main/java/org/hyperledger/besu/controller/ConsensusScheduleBesuControllerBuilder.java
+++ b/app/src/main/java/org/hyperledger/besu/controller/ConsensusScheduleBesuControllerBuilder.java
@@ -49,6 +49,8 @@ import org.hyperledger.besu.ethereum.forkid.ForkIdManager;
 import org.hyperledger.besu.ethereum.mainnet.BalConfiguration;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.p2p.config.SubProtocolConfiguration;
+import org.hyperledger.besu.ethereum.p2p.network.ProtocolManager;
+import org.hyperledger.besu.ethereum.p2p.rlpx.wire.SubProtocol;
 import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
@@ -225,9 +227,37 @@ public class ConsensusScheduleBesuControllerBuilder extends BesuControllerBuilde
   protected SubProtocolConfiguration createSubProtocolConfiguration(
       final EthProtocolManager ethProtocolManager,
       final Optional<SnapProtocolManager> maybeSnapProtocolManager) {
-    return besuControllerBuilderSchedule
-        .get(besuControllerBuilderSchedule.keySet().stream().skip(1).findFirst().orElseThrow())
-        .createSubProtocolConfiguration(ethProtocolManager, maybeSnapProtocolManager);
+    // During consensus migration, we need BOTH wire protocols registered.
+    // This allows nodes to communicate before AND after the migration block.
+    // Previously used .skip(1) which was non-deterministic with HashMap ordering.
+    //
+    // We merge all sub-protocol configurations, which registers both:
+    // - IBF/1 (IBFT2) for pre-migration communication
+    // - istanbul/100 (QBFT) for post-migration communication
+    final SubProtocolConfiguration mergedConfig = new SubProtocolConfiguration();
+    final java.util.Set<String> addedProtocolNames = new java.util.HashSet<>();
+
+    // Add sub-protocols from each consensus builder (sorted by block number for determinism)
+    besuControllerBuilderSchedule.entrySet().stream()
+        .sorted(Map.Entry.comparingByKey())
+        .forEach(
+            entry -> {
+              final SubProtocolConfiguration builderConfig =
+                  entry.getValue().createSubProtocolConfiguration(ethProtocolManager, maybeSnapProtocolManager);
+              final List<SubProtocol> subProtocols = builderConfig.getSubProtocols();
+              final List<ProtocolManager> protocolManagers = builderConfig.getProtocolManagers();
+              for (int i = 0; i < subProtocols.size(); i++) {
+                final SubProtocol subProtocol = subProtocols.get(i);
+                final ProtocolManager protocolManager = protocolManagers.get(i);
+                // Only add if not already present (avoid duplicates like EthProtocol)
+                if (!addedProtocolNames.contains(subProtocol.getName())) {
+                  mergedConfig.withSubProtocol(subProtocol, protocolManager);
+                  addedProtocolNames.add(subProtocol.getName());
+                }
+              }
+            });
+
+    return mergedConfig;
   }
 
   @Override


### PR DESCRIPTION
## Summary

This PR fixes a critical bug that prevents successful **IBFT2 → QBFT consensus migration** in Besu. During migration, nodes would stall and fail to produce blocks because they could only speak one BFT wire protocol instead of both.

## Problem

When running a consensus migration from IBFT2 to QBFT using a `transitions` configuration in genesis, the network would stall before reaching the fork block. Nodes could not exchange IBFT2 messages even though they were still running IBFT2 consensus pre-fork.

### Root Cause

In `ConsensusScheduleBesuControllerBuilder.createSubProtocolConfiguration()`, the original code was:

```java
return besuControllerBuilderSchedule
    .get(besuControllerBuilderSchedule.keySet().stream().skip(1).findFirst().orElseThrow())
    .createSubProtocolConfiguration(ethProtocolManager, maybeSnapProtocolManager);
```

**Issues with this approach:**

1. **Non-deterministic ordering**: `besuControllerBuilderSchedule` is a `Map` (HashMap), so `keySet().stream().skip(1)` produces unpredictable results
2. **Only one protocol registered**: Only the sub-protocol from ONE consensus mechanism was registered
3. **Peer communication failure**: Nodes couldn't exchange IBFT2 messages → block production stalls

## Solution

The fix registers **all BFT sub-protocols** from all scheduled consensus mechanisms:

- **IBF/1** (IBFT2) - for pre-migration communication  
- **istanbul/100** (QBFT) - for post-migration communication

## Testing

### Migration Test Results

| Phase | Block | Consensus | Status |
|-------|-------|-----------|--------|
| Pre-fork | #47-49 | IBFT2 | ✅ IbftBesuControllerBuilder |
| Fork | #50 | QBFT | ✅ QbftBesuControllerBuilder |
| Post-fork | #50-100+ | QBFT | ✅ Continuous block production |

### Log Evidence

```
# Pre-fork (IBFT2)
IbftBesuControllerBuilder | Produced #49 / 0 tx / ...

# Fork block (QBFT takes over)  
QbftBesuControllerBuilder | Imported empty block #50 / 0 tx / ...

# Post-fork (QBFT continues)
QbftBesuControllerBuilder | Produced empty block #73 / 0 tx / ...
```

## Checklist

- [x] Manual migration test (IBFT2 → QBFT) - **PASSED**
- [x] No database changes
- [ ] spotless / unit tests / acceptance tests

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

## Summary by Sourcery

Register all relevant BFT sub-protocols during consensus transitions to ensure nodes can communicate both before and after IBFT2→QBFT migration.

Bug Fixes:
- Fix non-deterministic and incomplete sub-protocol registration that could prevent IBFT2 messages from being exchanged during consensus migration.

Enhancements:
- Merge and deduplicate sub-protocol configurations from all scheduled consensus builders in a deterministic order to support multiple BFT wire protocols across transitions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes IBFT2→QBFT migration by registering all required BFT wire protocols so nodes can communicate before and after the fork and keep producing blocks.

- **Bug Fixes**
  - Merge sub-protocol configs from all scheduled builders, sorted by block number.
  - Register both IBF/1 (IBFT2) and istanbul/100 (QBFT).
  - Deduplicate protocols by name to avoid double registration.
  - Removes non-deterministic selection that caused IBFT2 message failures and stalls.

<sup>Written for commit c0f000df7a022bc403bfd62910653ea032b41cfe. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

